### PR TITLE
fix ScramRegex to match all valid Base64 characters

### DIFF
--- a/src/Ubiety.Scram.Core/Attributes/ScramAttribute.cs
+++ b/src/Ubiety.Scram.Core/Attributes/ScramAttribute.cs
@@ -166,7 +166,7 @@ namespace Ubiety.Scram.Core.Attributes
         }
 
         // language=regex
-        [GeneratedRegex(@"(?:(?<gs2>^[ny]?(?:p=.+?)?),)?(?:,?(?<attr>.=[a-zA-Z0-9\+\=]+?),?)+$", RegexOptions.CultureInvariant)]
+        [GeneratedRegex(@"(?:(?<gs2>^[ny]?(?:p=.+?)?),)?(?:,?(?<attr>.=[a-zA-Z0-9+=/]+?),?)+$", RegexOptions.CultureInvariant)]
         private static partial Regex ScramRegex();
     }
 }


### PR DESCRIPTION
The regex didn't match forward-slash `/`, but it is a valid Base64-character.
([Base 64 Encoding](https://datatracker.ietf.org/doc/html/rfc4648#section-4))